### PR TITLE
Harden Vercel API initialization and fix shared schema import path

### DIFF
--- a/searchforhelp-testing/api/index.ts
+++ b/searchforhelp-testing/api/index.ts
@@ -1,15 +1,23 @@
-import type { VercelRequest, VercelResponse } from '@vercel/node';
-import express from 'express';
-import { registerRoutes } from '../server/routes.js';
-import { createServer } from 'http';
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import express from "express";
+import { registerRoutes } from "../server/routes";
+import { createServer } from "http";
 
 const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 
 const httpServer = createServer(app);
-await registerRoutes(httpServer, app);
+let routesInitialized = false;
+
+async function ensureRoutes() {
+  if (routesInitialized) {
+    return;
+  }
+  await registerRoutes(httpServer, app);
+  routesInitialized = true;
+}
 
 export default (req: VercelRequest, res: VercelResponse) => {
-  return app(req, res);
+  return ensureRoutes().then(() => app(req, res));
 };

--- a/searchforhelp-testing/server/storage.ts
+++ b/searchforhelp-testing/server/storage.ts
@@ -1,4 +1,4 @@
-import { type User, type InsertUser, type Category, type Helpline } from "@shared/schema";
+import { type User, type InsertUser, type Category, type Helpline } from "../shared/schema";
 import { randomUUID } from "crypto";
 
 export interface IStorage {


### PR DESCRIPTION
### Motivation
- Vercel serverless functions can fail when routes are registered at module top-level and when TypeScript path aliases or explicit `.js` extensions prevent runtime resolution. 
- Avoid repeated route registration and top-level await issues in serverless environments by initializing routes on demand. 
- Ensure the server bundle can resolve the shared schema module at runtime without relying on path aliases.

### Description
- Replace alias import `@shared/schema` with a relative import `../shared/schema` in `server/storage.ts`. 
- Defer route registration by replacing the top-level `await registerRoutes(...)` with an `ensureRoutes()` function that initializes routes once, and call it before handling the first request in `api/index.ts`. 
- Remove the explicit `.js` extension from the `../server/routes` import and normalize import quoting in `api/index.ts`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698327f1ee608321b7db1f8fca2ac92a)